### PR TITLE
git improve German translation

### DIFF
--- a/custom_components/ha_washdata/translations/de.json
+++ b/custom_components/ha_washdata/translations/de.json
@@ -314,7 +314,7 @@
       },
       "assign_profile_phases": {
         "title": "Phasenzeiträume zuweisen",
-        "description": "Phasenvorschau für Profil: **{profile_name}**\n\n{timeline_svg}\n\n**Aktuelle Zeiträume:**\n{current_ranges}\n\nFolgenden Aktionen verwenden, um Zeiträume hinzuzufügen, zu bearbeiten, zu löschen oder zu speichern.",
+        "description": "Phasenvorschau für Profil: **{profile_name}**\n\n{timeline_svg}\n\n**Aktuelle Zeiträume:**\n{current_ranges}\n\nFolgende Aktionen verwenden, um Zeiträume hinzuzufügen, zu bearbeiten, zu löschen oder zu speichern.",
         "data": {
           "action": "Aktion"
         }


### PR DESCRIPTION
# Translation PR

## Checklist

- [x] I am a native ~~or fluent~~ speaker of the language I am translating, ~~or I have had the translation reviewed by one.~~
- [x] I have only modified files under `custom_components/ha_washdata/translations/`.
- [x] I have not changed any English (`en.json`) strings — only translated files.
- [x] All keys present in `en.json` are present in my translation file (no keys added or removed).
- [ ] I have tested the translation by loading it in Home Assistant and checking that strings display correctly.

## Language

German (de)

## What was changed

- [ ] New language added
- [x] Corrected existing translation(s)
- [ ] Updated strings to match recent English changes

## Specific corrections (if applicable)

- replace imperatives with infinitives (these were probably from an automatic machine translation)
- uniform translations (mostly for "phase", "range", "trim" and "label")
- minor further edits

## Additional notes

Phrases like "label cycle" are usually meant to be infinitives as in "(to) label (a) cycle", but machine translations often interpret them as imperatives (a command to label a cycle) or sometimes even worse, as a noun ("a label cycle"/"a cycle to label"). Most of this commit is to fix these wrong translations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated German UI translations for improved clarity and consistency: reworded labels, prompts, status/help text and error messages; harmonized phase/profile terminology and cycle wording.
  * Clarified thresholds, notifications, advanced settings, editor workflows and diagnostics; refined field titles, descriptions and placeholders; added and adjusted translation keys to provide clearer guidance across setup and management flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->