### PR TITLE
[FIX] auto_label_cycles service calls non-existent ProfileStore method

### DIFF
--- a/custom_components/ha_washdata/__init__.py
+++ b/custom_components/ha_washdata/__init__.py
@@ -418,7 +418,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 raise ValueError("Integration not loaded for this device")
 
             manager = hass.data[DOMAIN][entry_id]
-            stats = await manager.profile_store.auto_label_unlabeled_cycles(
+            stats = await manager.profile_store.auto_label_cycles(
                 confidence_threshold
             )
             manager.notify_update()

--- a/tests/test_auto_label.py
+++ b/tests/test_auto_label.py
@@ -1,8 +1,48 @@
 
+import ast
+from pathlib import Path
+
 import pytest
 from unittest.mock import MagicMock, AsyncMock, patch
 from datetime import datetime, timedelta
 from custom_components.ha_washdata.profile_store import ProfileStore, MatchResult
+
+
+def test_service_handlers_call_existing_profile_store_methods():
+    """Every ``...profile_store.<attr>`` call in __init__.py must resolve to a
+    real ProfileStore attribute.
+
+    Regression guard for the ``auto_label_cycles`` service handler, which
+    called the non-existent ``profile_store.auto_label_unlabeled_cycles``.
+    The service registered fine, so this was invisible until invoked, where
+    it raised ``AttributeError`` (surfaced as an HTTP 500). The existing
+    tests only exercised ``ProfileStore.auto_label_cycles`` directly and
+    never the handler, so the name mismatch slipped through.
+    """
+    init_path = (
+        Path(__file__).resolve().parents[1]
+        / "custom_components"
+        / "ha_washdata"
+        / "__init__.py"
+    )
+    tree = ast.parse(init_path.read_text(encoding="utf-8"))
+    valid = set(dir(ProfileStore))
+
+    missing = sorted(
+        {
+            node.attr
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Attribute)
+            and isinstance(node.value, ast.Attribute)
+            and node.value.attr == "profile_store"
+            and node.attr not in valid
+        }
+    )
+
+    assert not missing, (
+        "__init__.py calls ProfileStore methods that do not exist: "
+        f"{missing}"
+    )
 
 @pytest.fixture
 def mock_hass():


### PR DESCRIPTION
## Linked Accepted Issue

Closes #277

## Description

The `ha_washdata.auto_label_cycles` service handler calls `manager.profile_store.auto_label_unlabeled_cycles(...)`, which does not exist — the actual `ProfileStore` method is `auto_label_cycles(confidence_threshold, overwrite=False)`. The service registers fine, so the bug is invisible until invoked, where it raises `AttributeError` and surfaces as HTTP 500. In effect the service has never worked, silently letting the retroactive-labeling backlog accumulate.

The real method returns the same `{labeled, relabeled, skipped, total}` dict the handler already reads (`stats["labeled"]`, `stats["skipped"]`), so renaming the call is sufficient — no behavior change beyond making the service work.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🧪 Test additions/improvements

## Changes Made

- [x] `__init__.py`: rename `profile_store.auto_label_unlabeled_cycles(...)` → `profile_store.auto_label_cycles(...)` in `handle_auto_label_cycles`
- [x] `tests/test_auto_label.py`: add a regression test that statically (AST) asserts every `...profile_store.<attr>` call in `__init__.py` resolves to a real `ProfileStore` attribute. The existing tests exercised `ProfileStore.auto_label_cycles` directly but never the service handler, which is why the name mismatch slipped through.

## Testing

Ran `./run_tests.sh`. The `auto_label` suite passes 4/4; the new regression test fails pre-fix (`missing == ['auto_label_unlabeled_cycles']`) and passes post-fix.

Full-suite caveat for transparency: in my local environment the default fast suite has 6 collection errors (missing optional dev deps such as `nicegui`, and an import-path setup needed for test modules that import `ha_washdata` directly rather than `custom_components.ha_washdata`). With `PYTHONPATH` set and those optional-dep files ignored, the result is **298 passed, 5 failed + 1 error** — and that 5+1 reproduces identically on a clean `main` checkout (verified via `git stash`), i.e. it is harness/version drift in my setup, unrelated to this change.

`python3 -m compileall custom_components tests` passes (exit 0). `ruff` reports no new findings on the changed lines.

Manually verified on a live install: the service returned HTTP 500 before the fix and `Successfully executed` after.

- [x] Unit tests added/updated
- [x] Manual testing completed
- [ ] Ran `./run_tests.sh` with a fully green suite (see caveat above — pre-existing env-only failures)

**Tested on:**
- Home Assistant version: 2026.6.1
- WashData version: 0.4.5 / `main`
- Device type(s): Washing Machine, Dryer, Dishwasher (service is device-agnostic)

## Breaking Changes?

- [ ] This PR includes **breaking changes**

## Checklist

- [x] My code follows the project's code standards (PEP 8, type hints) — `ruff` clean on the changed lines
- [x] I've added corresponding tests
- [x] I've checked that `python3 -m compileall custom_components tests` passes
- [ ] I've run `./run_tests.sh` and **all** tests pass — see Testing caveat (only pre-existing, env-only failures remain; the relevant suite passes)
- [x] No hardcoded UI strings
- [x] I've reviewed my own code for quality
- [x] I've synced with upstream: `git fetch upstream && git rebase upstream/main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the `auto_label_cycles` service to correctly process cycle labeling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->