### PR TITLE
fix: surface STATE_CLEAN for finished cycles (#282)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to WashData will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### 🐛 Bug Fixes
+
+- **`Clean` State Never Shown for Washing Machines** (#282): A completed cycle ends in `STATE_FINISHED`, but `check_state()` only surfaced `STATE_CLEAN` for `STATE_OFF`, so with a Door Sensor configured the `Clean` state was unreachable and `sensor.<name>_state` showed `Finished`. `check_state()` now reports `Clean` for finished cycles too.
+
 ## 0.4.5.1 - 2026-06-11
 
 ### 🐛 Bug Fixes

--- a/custom_components/ha_washdata/manager.py
+++ b/custom_components/ha_washdata/manager.py
@@ -154,6 +154,7 @@ from .const import (
     DEFAULT_NOTIFY_UNLOAD_DELAY_MINUTES,
     DEFAULT_NOTIFY_UNLOAD_MESSAGE,
     STATE_CLEAN,
+    STATE_FINISHED,
     DEFAULT_NOTIFY_TITLE,
     DEFAULT_NOTIFY_START_MESSAGE,
     DEFAULT_NOTIFY_FINISH_MESSAGE,
@@ -4186,7 +4187,12 @@ class WashDataManager:
         """Return current detector state."""
         if self.recorder.is_recording:
             return STATE_RUNNING
-        if self._is_clean_state and self.detector.state == STATE_OFF:
+        # A completed cycle ends in STATE_FINISHED, not STATE_OFF; accept both
+        # or the door-sensor Clean state (#153) is never surfaced (#282).
+        if self._is_clean_state and self.detector.state in (
+            STATE_OFF,
+            STATE_FINISHED,
+        ):
             return STATE_CLEAN
         if self._is_user_paused:
             return STATE_USER_PAUSED

--- a/tests/repro/test_issue_282.py
+++ b/tests/repro/test_issue_282.py
@@ -1,0 +1,74 @@
+"""Reproduction for issue #282.
+
+STATE_CLEAN was unreachable for a washing machine: a completed cycle ends with
+the detector in STATE_FINISHED, but check_state() only surfaced STATE_CLEAN when
+detector.state == STATE_OFF, so the door-sensor Clean state (#153) never showed.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from custom_components.ha_washdata.const import (
+    CONF_MIN_POWER,
+    CONF_PROGRESS_RESET_DELAY,
+    STATE_CLEAN,
+    STATE_FINISHED,
+    STATE_OFF,
+)
+from custom_components.ha_washdata.manager import WashDataManager
+
+
+@pytest.fixture
+def mock_hass():
+    """Minimal mocked HomeAssistant instance."""
+    hass = MagicMock()
+    hass.data = {}
+    hass.async_create_task = MagicMock(
+        side_effect=lambda coro: getattr(coro, "close", lambda: None)()
+    )
+    return hass
+
+
+@pytest.fixture
+def mock_entry():
+    """Minimal mocked config entry."""
+    entry = MagicMock()
+    entry.entry_id = "test_entry"
+    entry.title = "Test Washer"
+    entry.options = {
+        CONF_MIN_POWER: 2.0,
+        CONF_PROGRESS_RESET_DELAY: 150,
+    }
+    return entry
+
+
+async def test_clean_state_surfaced_after_finished(mock_hass, mock_entry):
+    """check_state() must report CLEAN when the cycle is finished with laundry inside."""
+    now = datetime(2026, 2, 9, 12, 0, 0, tzinfo=timezone.utc)
+
+    with patch("homeassistant.util.dt.now", return_value=now), patch(
+        "custom_components.ha_washdata.manager.ProfileStore"
+    ), patch(
+        "custom_components.ha_washdata.manager.CycleDetector"
+    ) as mock_detector_class:
+        mock_detector = mock_detector_class.return_value
+        manager = WashDataManager(mock_hass, mock_entry)
+        manager.recorder = MagicMock(is_recording=False)
+
+        # Cycle completed with the door closed: _is_clean_state is set and the
+        # detector's terminal state for a normal wash is FINISHED.
+        manager._is_clean_state = True
+        mock_detector.state = STATE_FINISHED
+        assert manager.check_state() == STATE_CLEAN  # was FINISHED before the fix
+
+        # Still works for the legacy OFF terminal.
+        mock_detector.state = STATE_OFF
+        assert manager.check_state() == STATE_CLEAN
+
+        # Without the clean flag, the raw detector state is reported (never CLEAN).
+        manager._is_clean_state = False
+        mock_detector.state = STATE_FINISHED
+        assert manager.check_state() == STATE_FINISHED


### PR DESCRIPTION
## Linked Accepted Issue (required for non-translation PRs)

Closes #282

## Description

A completed wash ends with the detector in `STATE_FINISHED`, but `check_state()` only returned `STATE_CLEAN` when `detector.state == STATE_OFF`. The detector only reaches `OFF` via the progress-reset expiry, which clears `_is_clean_state` at the same time, so `STATE_CLEAN` was unreachable — with a Door Sensor configured the state showed `Finished` instead of `Clean`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- [x] `check_state()` now returns `STATE_CLEAN` when the clean flag is set and `detector.state in (STATE_OFF, STATE_FINISHED)`
- [x] Added `tests/repro/test_issue_282.py`
- [x] CHANGELOG entry

## Testing

- [x] Unit tests added/updated
- [x] Ran: `./run_tests.sh`

**Tested on:**
- Home Assistant version: 2026.6.3
- WashData version: 0.4.5.1
- Device type(s): Washing Machine

## Breaking Changes?

- [ ] This PR includes **breaking changes**

## Checklist

- [x] My code follows the project's code standards (PEP 8, type hints)
- [x] I've added/updated docstrings for new functions/classes
- [x] I've added corresponding tests (if applicable)
- [x] I've updated documentation (README, CHANGELOG, etc. if applicable)
- [x] I've checked that `python3 -m compileall custom_components tests` passes
- [x] I've run `./run_tests.sh` and all tests pass
- [x] **No hardcoded UI strings** - all user-facing text is in `strings.json` and `translations/`
- [x] I've reviewed my own code for quality
- [x] I've synced with upstream: `git fetch upstream && git rebase upstream/main`
