### PR TITLE
Modify feedback notification message for clarity

### DIFF
--- a/custom_components/ha_washdata/translations/en.json
+++ b/custom_components/ha_washdata/translations/en.json
@@ -772,7 +772,7 @@
       "timestamp_mode_cycle_required": "Please select a source cycle when using timestamp mode.",
       "no_phase_ranges": "No phase ranges are available for that action yet.",
       "feedback_notification_title": "WashData: Verify Cycle ({device})",
-      "feedback_notification_message": "**Device**: {device}\n**Program**: {program} ({confidence}% confidence)\n**Time**: {time}\n\nWashData needs your help to verify this detected cycle.\n\nPlease go to **Settings > Devices & Services > WashData > Configure > Learning Feedbacks** to confirm or correct this result.",
+      "feedback_notification_message": "**Device**: {device}\n**Program**: {program} ({confidence}% confidence)\n**Time**: {time}\n\nWashData needs your help to verify this detected cycle.\n\nPlease go to **Settings > Devices & Services > WashData > Configure > Review Learning Feedbacks** to confirm or correct this result.",
       "suggestions_ready_notification_title": "WashData: Suggested Settings Ready ({device})",
       "suggestions_ready_notification_message": "The **Suggested Settings** sensor now reports **{count}** actionable recommendations.\n\nTo review and apply them: **Settings > Devices & Services > WashData > Configure > Advanced Settings > Apply Suggested Values**.\n\nSuggestions are optional and shown for review before you save.",
       "trim_range_invalid": "Start must be before end. Please adjust your trim points.",


### PR DESCRIPTION
## Description

Updated the feedback notification message to direct users to 'Review Learning Feedbacks' instead of 'Learning Feedbacks'. That matches what the configuration dialogue shows.

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔄 Refactor (code reorganization with no behavior change)
- [ ] 📚 Documentation update
- [ ] 🧪 Test additions/improvements
- [ ] ⚡ Performance improvement
- [ ] 🎨 UI/UX improvement
- [x] 🌍 Translation/Localization

## For Translations

<!-- If this is a translation PR, include: -->

- [x] Language: English
- [ ] I've verified JSON syntax: `python3 -m json.tool custom_components/ha_washdata/translations/[lang].json`
- [ ] All keys match the English translation file

**Thank you for contributing to WashData!** 🙏

Before hitting submit, please make sure:
1. ✅ PR title clearly describes the change
2. ✅ Description is detailed enough for reviewers to understand
4. ✅ You've reviewed the [CONTRIBUTING.md](https://github.com/3dg1luk43/ha_washdata/blob/main/CONTRIBUTING.md) guide
5. ✅ You've read our [Code of Conduct](https://github.com/3dg1luk43/ha_washdata/blob/main/CODE_OF_CONDUCT.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the wording of the WashData cycle verification notification to reflect a new navigation path in the app.
  * The guidance now points to **Configure > Review Learning Feedbacks** instead of **Configure > Learning Feedbacks**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->