### PR TITLE
fix(ci): point setup-python's pip cache at requirements-dev.txt

### DIFF
--- a/.github/workflows/release_preflight.yml
+++ b/.github/workflows/release_preflight.yml
@@ -33,6 +33,11 @@ jobs:
         with:
           python-version: "3.13"
           cache: pip
+          # REQUIRED: `cache: pip` globs for requirements.txt / pyproject.toml, neither
+          # of which this repo has, and a miss is a hard step FAILURE - not a skipped
+          # cache. That failed the whole job before a single check ran, so the preflight
+          # reported red without ever verifying anything (v0.5.5).
+          cache-dependency-path: requirements-dev.txt
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "20"


### PR DESCRIPTION
Release Preflight failed on the `v0.5.5` tag after 7 seconds, before running a single check.

## Cause

The `actions/setup-python` step, not anything about the release:

```
##[error]No file in /home/runner/work/ha_washdata/ha_washdata matched to
[**/requirements.txt or **/pyproject.toml], make sure you have checked out the target repository
```

`cache: pip` globs for `**/requirements.txt` or `**/pyproject.toml`. This repo has neither - only `requirements-dev.txt` - and a glob miss is a hard **step failure**, not a skipped cache. The job died at setup, so the preflight reported red while never verifying anything: the worst failure mode for a gate, because it is indistinguishable from a genuinely bad release.

## Fix

Add `cache-dependency-path: requirements-dev.txt`. `tests.yml` is unaffected (its `setup-python` has no `cache:`).

## The v0.5.5 release itself is fine

Verified independently, since a red preflight on a tag deserves proof rather than assurance:

- **Artifacts verify at the tag and on main.** `build_panel.mjs --check` against the `v0.5.5` and `main` trees: *Panel build is current* for both (source hash and artifact hash both match the manifest).
- **The shipped `.min.js` really are builds of the shipped sources.** Rebuilt from the tag's own `www/*.js` and byte-compared: `ha-washdata-panel.min.js` and `ha-washdata-card.min.js` are **identical** to what the tag ships.
- **`main` and `v0.5.5` are the same commit** (`19f9c98`), and `hacs.json` has `zip_release: false`, so HACS serves users exactly that verified tree.
- **The full preflight passes on the tag.** Ran `release_check.sh --tag v0.5.5` against `git archive v0.5.5`: artifacts current, ws-types/WS_API current, version agrees everywhere (0.5.5), translations clean, python compiles, panel + card parse, render smoke, fast suite green.

So users on 0.5.5 have the correct minified bundles; only the CI gate was broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)