### PR TITLE
fix(ci): make the preflight's test suite actually run (follow-up to #397)

### DIFF
--- a/devtools/release_check.sh
+++ b/devtools/release_check.sh
@@ -270,13 +270,26 @@ else
 fi
 
 # ── 6. tests ─────────────────────────────────────────────────────────────────
+# A suite failure prints its tail. Swallowing it entirely meant a CI log said only
+# "fast suite failed" with no way to tell a real regression from a collection error -
+# and a collection error takes the WHOLE suite with it, so "failed" can mean "nothing
+# ran at all" (v0.5.5: a missing optional devtools import did exactly that).
+run_suite() {
+  local label="$1" out
+  shift
+  if out=$("$@" 2>&1); then
+    pass "$label"
+  else
+    fail "$label failed" "$*"
+    printf '%s\n' "$out" | tail -25 | sed 's/^/        | /'
+  fi
+}
+
 head_ "Tests"
-if "$PY" -m pytest tests/ -q >/dev/null 2>&1; then pass "fast suite"
-else fail "fast suite failed" "$PY -m pytest tests/ -q"; fi
+run_suite "fast suite" "$PY" -m pytest tests/ -q
 
 if [[ $FULL -eq 1 ]]; then
-  if "$PY" -m pytest tests/ -q -m slow >/dev/null 2>&1; then pass "slow suite"
-  else fail "slow suite failed" "$PY -m pytest tests/ -q -m slow"; fi
+  run_suite "slow suite" "$PY" -m pytest tests/ -q -m slow
   if command -v npx >/dev/null 2>&1; then
     if (cd playwright-tests && npx playwright test --reporter=dot >/dev/null 2>&1); then pass "E2E suite"
     else fail "E2E suite failed" "cd playwright-tests && npx playwright test"; fi

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,7 +24,7 @@ pytest_plugins = ["pytest_homeassistant_custom_component"]
 # import tests.mock_imports  # pylint: disable=unused-import
 
 @pytest.fixture
-def mock_hass():
+def mock_hass(tmp_path_factory):
     """Mock Home Assistant instance."""
     hass = MagicMock()
     hass.data = {}
@@ -35,7 +35,13 @@ def mock_hass():
         return target(*args)
 
     hass.async_add_executor_job = MagicMock(side_effect=_async_executor_mock)
-    hass.config.path = lambda *args: "/mock/path/" + "/".join(args)
+    # A REAL temp dir, not a fabricated "/mock/path" absolute path. Most tests patch
+    # WashDataStore so nothing is written, but the ones that don't (test_smart_history)
+    # reach HA's Store and actually save - which only succeeded because the developer
+    # happened to be root, and failed on CI with
+    # `PermissionError: [Errno 13] Permission denied: '/mock'`.
+    _config_dir = tmp_path_factory.mktemp("ha_config")
+    hass.config.path = lambda *args: str(_config_dir.joinpath(*args))
     return hass
 
 @pytest.fixture

--- a/tests/test_mock_socket_synthesis.py
+++ b/tests/test_mock_socket_synthesis.py
@@ -17,7 +17,23 @@
 
 import pytest
 import random
-from devtools.mqtt_mock_socket import CycleSynthesizer
+
+# `devtools/mqtt_mock_socket.py` is the manual-testing MQTT mock: a NiceGUI app whose
+# module scope imports nicegui (and decorates a page with @ui.page at import time).
+# nicegui is deliberately NOT in requirements-dev.txt - that file is a single pinned
+# pytest-homeassistant-custom-component plus numpy, and pulling a web GUI framework into
+# every CI run for one synthesis test is the wrong trade.
+#
+# The skip must be an importorskip, not a bare import: a plain ImportError here
+# INTERRUPTS COLLECTION of the whole suite, so a missing optional devtools dependency
+# silently took all ~1800 tests with it (which is exactly what happened in CI - the
+# release preflight reported "fast suite failed" while nothing had run).
+pytest.importorskip(
+    "nicegui",
+    reason="devtools mock-socket GUI dependency; install nicegui to run these",
+)
+
+from devtools.mqtt_mock_socket import CycleSynthesizer  # noqa: E402
 
 def test_synthesizer_amplitude_scaling():
     """Test that amplitude scaling can be applied."""


### PR DESCRIPTION
#397 was merged after its first commit, so main has the `setup-python` cache fix but not the two problems that fix uncovered. Without these, Release Preflight still fails on main - just later in the job.

Both were found only because the pip-cache fix let the preflight run for the first time.

## 1. The whole test suite was silently not running

`tests/test_mock_socket_synthesis.py` imports `devtools/mqtt_mock_socket.py`, whose module scope imports `nicegui`. That is deliberately not in `requirements-dev.txt` (a single pinned `pytest-homeassistant-custom-component` plus numpy - pulling a web GUI framework into every CI run for one synthesis test is the wrong trade), so in CI the `ImportError` **interrupted collection** and all ~1800 tests never ran, surfacing only as `fast suite failed`.

`pytest.importorskip("nicegui")` makes a missing optional devtools dependency skip those 3 tests instead of the whole suite. Verified in a clean venv built from `requirements-dev.txt`: **1807 passed, 1 skipped** (previously 0 ran).

## 2. Two tests only passed because the developer is root

```
FAILED tests/test_smart_history.py::test_smart_merge_logic
  - PermissionError: [Errno 13] Permission denied: '/mock'
```

The shared `mock_hass` fixture hardcoded `hass.config.path = lambda *a: "/mock/path/" + "/".join(a)`. Most tests patch `WashDataStore` so nothing is written, but `test_smart_history` does not - it reaches HA's real `Store` and saves, which only ever worked because a root developer could create `/mock` at the filesystem root. A normal CI user cannot.

The fixture now uses a real `tmp_path_factory` directory, so a test that actually saves works for any user and writes nothing outside its temp dir. Verified by running those tests as an unprivileged user (uid 65534): both pass, and `/mock` is no longer created. No test asserted on the literal path.

## Plus: the gate now says *why* it failed

`release_check.sh` swallowed suite output entirely, so a CI log said only `fast suite failed` - with no way to tell a real regression from a collection error (which means nothing ran at all). It now prints the tail of a failing suite; that is what made both problems above diagnosable in one look. Verified with a planted failing test that the assertion appears in the log.

## Result

With all three commits, Release Preflight is **green** and genuinely verifies artifacts, ws-types/WS_API, version agreement, translations, compile, parse, render smoke, **the fast suite**, and artifact tracking: [passing run](https://github.com/3dg1luk43/ha_washdata/actions/runs/32562451328).

🤖 Generated with [Claude Code](https://claude.com/claude-code)